### PR TITLE
Support activerecord-jdbcmssql-adapter on JRuby

### DIFF
--- a/lib/sqlserver/foreigner.rb
+++ b/lib/sqlserver/foreigner.rb
@@ -1,4 +1,6 @@
 require "sqlserver/foreigner/version"
 require 'foreigner'
 
-Foreigner::Adapter.register 'sqlserver', File.expand_path('../foreigner/sqlserver-adapter.rb', __FILE__)
+['sqlserver', 'mssql'].each do |adapter|
+  Foreigner::Adapter.register adapter, File.expand_path('../foreigner/sqlserver-adapter.rb', __FILE__)
+end

--- a/sqlserver-foreigner.gemspec
+++ b/sqlserver-foreigner.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency("foreigner", ">0")
-  gem.add_dependency("activerecord-sqlserver-adapter", ">0")
 
   gem.add_development_dependency "rake"
 end


### PR DESCRIPTION
Fixes #1
I've also removed the dependency on activerecord-sqlserver-adapter - like Foreigner's gemspec, it only depends on activerecord itself.
